### PR TITLE
add missing dbus permissions

### DIFF
--- a/dev.aunetx.deezer.yml
+++ b/dev.aunetx.deezer.yml
@@ -18,6 +18,9 @@ finish-args:
   # Allow other instances to see lockfiles
   - --env=TMPDIR=/var/tmp
   # DBus permissions
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.kde.StatusNotifierItem
+  - --talk-name=com.canonical.dbusmenu
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.SettingsDaemon

--- a/dev.aunetx.deezer.yml
+++ b/dev.aunetx.deezer.yml
@@ -18,6 +18,7 @@ finish-args:
   # Allow other instances to see lockfiles
   - --env=TMPDIR=/var/tmp
   # DBus permissions
+  - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.SettingsDaemon
   - --talk-name=org.gnome.SessionManager


### PR DESCRIPTION
adds the following permissions:
`org.freedesktop.PowerManagement`
without this permission the app can't prevent sleep on kde plasma

`org.kde.StatusNotifierWatcher`
`org.kde.StatusNotifierItem`
`com.canonical.dbusmenu`
without these the systray icon will not be able to restore the window or exit the app, though this wil cause the icon to not load or be invisible, maybe its possible to fix this by updating node or changing something on the icon files 🤔