### PR TITLE
Replace `patch-desktop-filename` with `patch-electron-desktop-filename`

### DIFF
--- a/dev.aunetx.deezer.yml
+++ b/dev.aunetx.deezer.yml
@@ -74,4 +74,4 @@ modules:
       - install -Dm644 dev.aunetx.deezer.appdata.xml /app/share/appdata/dev.aunetx.deezer.appdata.xml
       - install -Dm644 /app/main/resources/dev.aunetx.deezer.svg /app/share/icons/hicolor/scalable/apps/dev.aunetx.deezer.svg
       - install -Dm644 /app/main/resources/dev.aunetx.deezer.desktop /app/share/applications/dev.aunetx.deezer.desktop
-      - patch-desktop-filename /app/main/resources/app.asar
+      - patch-electron-desktop-filename /app/main/resources/app.asar


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.